### PR TITLE
chore: add enumeration data type to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,0 +1,17 @@
+{
+    "name": "recommendationengine",
+    "name_pretty": "Recommendations AI",
+    "product_documentation": "https://cloud.google.com/recommendations-ai/",
+    "api_description": "delivers highly personalized product recommendations at scale.",
+    "client_documentation": "https://googleapis.dev/java/google-cloud-recommendations-ai/latest/index.html",
+    "release_level": "beta",
+    "transport": "grpc",
+    "language": "java",
+    "repo": "googleapis/java-recommendations-ai",
+    "repo_short": "java-recommendations-ai",
+    "distribution_name": "com.google.cloud:google-cloud-recommendations-ai",
+    "api_id": "recommendationengine.googleapis.com",
+    "requires_billing": true,
+    "library_type": "GAPIC_AUTO"
+  }
+  

--- a/sync-repo-settings.yaml
+++ b/sync-repo-settings.yaml
@@ -1,0 +1,50 @@
+
+# Whether or not rebase-merging is enabled on this repository.
+# Defaults to `true`
+rebaseMergeAllowed: false
+
+# Whether or not squash-merging is enabled on this repository.
+# Defaults to `true`
+squashMergeAllowed: true
+
+# Whether or not PRs are merged with a merge commit on this repository.
+# Defaults to `false`
+mergeCommitAllowed: false
+
+# Rules for master branch protection
+branchProtectionRules:
+# Identifies the protection rule pattern. Name of the branch to be protected.
+# Defaults to `master`
+- pattern: master
+  # Can admins overwrite branch protection.
+  # Defaults to `true`
+  isAdminEnforced: true
+  # Number of approving reviews required to update matching branches.
+  # Defaults to `1`
+  requiredApprovingReviewCount: 1
+  # Are reviews from code owners required to update matching branches.
+  # Defaults to `false`
+  requiresCodeOwnerReviews: true
+  # Require up to date branches
+  requiresStrictStatusChecks: false
+  # List of required status check contexts that must pass for commits to be accepted to matching branches.
+  requiredStatusCheckContexts:
+    - "dependencies (8)"
+    - "dependencies (11)"
+    - "linkage-monitor"
+    - "lint"
+    - "clirr"
+    - "units (7)"
+    - "units (8)"
+    - "units (11)"
+    - "Kokoro - Test: Integration"
+    - "cla/google"
+# List of explicit permissions to add (additive only)
+permissionRules:
+- team: yoshi-admins
+  permission: admin
+- team: yoshi-java-admins
+  permission: admin
+- team: yoshi-java
+  permission: push
+  


### PR DESCRIPTION
Adds a standard enumeration of library types in .repo-metadata.json